### PR TITLE
Allow returns without [ ]

### DIFF
--- a/ngc_flowctrl.c
+++ b/ngc_flowctrl.c
@@ -577,7 +577,7 @@ status_code_t ngc_flowctrl (uint32_t o_label, char *line, uint_fast8_t *pos, boo
                     else if((g65_return = !!grbl.on_macro_return))
                         ngc_flowctrl_unwind_stack(stack[stack_idx].file);
 
-                    if(ngc_eval_expression(line, pos, &value) == Status_OK) {
+                    if(read_real_value(line, pos, &value) == Status_OK) {
                         ngc_named_param_set("_value", value);
                         ngc_named_param_set("_value_returned", 1.0f);
                     } else


### PR DESCRIPTION
Use read_real_value for return statements, so that the returned value does not need to be in [ ]